### PR TITLE
Remove redundant virtual specifier [class.virtual]

### DIFF
--- a/src/Mamba/Code Analysis/Syntax/AssignmentExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/AssignmentExpressionSyntax.h
@@ -18,8 +18,8 @@ namespace Mamba
                                                  const std::shared_ptr<const class SyntaxToken> AssignmentToken,
                                                  const std::shared_ptr<const ExpressionSyntax> Expression) noexcept;
 
-        virtual std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
-        virtual SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> IdentifierToken;
         const std::shared_ptr<const class SyntaxToken> AssignmentToken;

--- a/src/Mamba/Code Analysis/Syntax/BinaryExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/BinaryExpressionSyntax.h
@@ -17,8 +17,8 @@ namespace Mamba
                                              const std::shared_ptr<const class SyntaxToken> OperatorToken,
                                              const std::shared_ptr<const class ExpressionSyntax> Right) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         std::shared_ptr<const class ExpressionSyntax> Left;
         std::shared_ptr<const class SyntaxToken> OperatorToken;

--- a/src/Mamba/Code Analysis/Syntax/BlockStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/BlockStatementSyntax.h
@@ -23,8 +23,8 @@ namespace Mamba
                                            std::vector<std::shared_ptr<const class StatementSyntax>>&& Statements,
                                            const std::shared_ptr<const class SyntaxToken> CloseBraceToken) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> OpenBraceToken;
         const std::vector<std::shared_ptr<const class StatementSyntax>> Statements;

--- a/src/Mamba/Code Analysis/Syntax/BreakStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/BreakStatementSyntax.h
@@ -13,8 +13,8 @@ namespace Mamba
         [[nodiscard]] BreakStatementSyntax(const std::shared_ptr<const class SyntaxTree> SyntaxTree,
                                            const std::shared_ptr<const class SyntaxToken> Keyword) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Keyword;
     };

--- a/src/Mamba/Code Analysis/Syntax/CallExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/CallExpressionSyntax.h
@@ -20,8 +20,8 @@ namespace Mamba
             const std::shared_ptr<const SeperatedSyntaxList<std::shared_ptr<const class SyntaxNode>>> Arguments,
             const std::shared_ptr<const class SyntaxToken> CloseParenthesisToken) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Identifier;
         const std::shared_ptr<const class SyntaxToken> OpenParenthesisToken;

--- a/src/Mamba/Code Analysis/Syntax/CompilationUnitSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/CompilationUnitSyntax.h
@@ -20,8 +20,8 @@ namespace Mamba
                                             std::vector<std::shared_ptr<const class MemberSyntax>>&& Members,
                                             std::shared_ptr<const class SyntaxToken> EndOfFileToken) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
 
         const std::vector<std::shared_ptr<const class MemberSyntax>> Members;
         std::shared_ptr<const class SyntaxToken> EndOfFileToken;

--- a/src/Mamba/Code Analysis/Syntax/ContinueStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ContinueStatementSyntax.h
@@ -14,8 +14,8 @@ namespace Mamba
         [[nodiscard]] ContinueStatementSyntax(const std::shared_ptr<const class SyntaxTree> SyntaxTree,
                                               const std::shared_ptr<const class SyntaxToken> Keyword) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Keyword;
     };

--- a/src/Mamba/Code Analysis/Syntax/DoWhileStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/DoWhileStatementSyntax.h
@@ -19,8 +19,8 @@ namespace Mamba
                                              const std::shared_ptr<const class SyntaxToken> WhileKeyword,
                                              const std::shared_ptr<const class ExpressionSyntax> Condition) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> DoKeyword;
         const std::shared_ptr<const class StatementSyntax> Body;

--- a/src/Mamba/Code Analysis/Syntax/ElseClauseSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ElseClauseSyntax.h
@@ -16,8 +16,8 @@ namespace Mamba
                                        const std::shared_ptr<const class SyntaxToken> ElseKeyword,
                                        const std::shared_ptr<const class StatementSyntax> ElseStatement) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> ElseKeyword;
         const std::shared_ptr<const class StatementSyntax> ElseStatement;

--- a/src/Mamba/Code Analysis/Syntax/ExpressionStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ExpressionStatementSyntax.h
@@ -16,8 +16,8 @@ namespace Mamba
             const std::shared_ptr<const class SyntaxTree> SyntaxTree,
             const std::shared_ptr<const class ExpressionSyntax> Expression) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class ExpressionSyntax> Expression;
     };

--- a/src/Mamba/Code Analysis/Syntax/ForStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ForStatementSyntax.h
@@ -25,8 +25,8 @@ namespace Mamba
                                          const std::shared_ptr<const class SyntaxToken> CloseParenthesisToken,
                                          const std::shared_ptr<const class StatementSyntax> Body) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Keyword;
         const std::shared_ptr<const class SyntaxToken> OpenParenthesisToken;

--- a/src/Mamba/Code Analysis/Syntax/FunctionDeclarationSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/FunctionDeclarationSyntax.h
@@ -23,8 +23,8 @@ namespace Mamba
             const NullableSharedPtr<const class TypeClauseSyntax> Type,
             const std::shared_ptr<const class BlockStatementSyntax> Body) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> FunctionKeyword;
         const std::shared_ptr<const class SyntaxToken> Identifier;

--- a/src/Mamba/Code Analysis/Syntax/GlobalStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/GlobalStatementSyntax.h
@@ -14,8 +14,8 @@ namespace Mamba
         [[nodiscard]] GlobalStatementSyntax(const std::shared_ptr<const class SyntaxTree> SyntaxTree,
                                             const std::shared_ptr<const class StatementSyntax> Statement) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class StatementSyntax> Statement;
     };

--- a/src/Mamba/Code Analysis/Syntax/IfStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/IfStatementSyntax.h
@@ -19,8 +19,8 @@ namespace Mamba
                                         const std::shared_ptr<const class StatementSyntax> ThenStatement,
                                         const NullableSharedPtr<const class ElseClauseSyntax> ElseClause) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> IfKeyword;
         const NullableSharedPtr<const class SyntaxToken> OpenParenthesisToken;

--- a/src/Mamba/Code Analysis/Syntax/LiteralExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/LiteralExpressionSyntax.h
@@ -22,8 +22,8 @@ namespace Mamba
                                               // https://zh.cppreference.com/w/cpp/language/elaborated_type_specifier
                                               const std::shared_ptr<const struct Literal> Value) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> LiteralToken;
         const std::shared_ptr<const struct Literal> Value;

--- a/src/Mamba/Code Analysis/Syntax/NameExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/NameExpressionSyntax.h
@@ -15,8 +15,8 @@ namespace Mamba
         [[nodiscard]] NameExpressionSyntax(const std::shared_ptr<const class SyntaxTree> SyntaxTree,
                                            const std::shared_ptr<const class SyntaxToken> IdentifierToken) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> IdentifierToken;
     };

--- a/src/Mamba/Code Analysis/Syntax/ParameterSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ParameterSyntax.h
@@ -16,8 +16,8 @@ namespace Mamba
                                       const std::shared_ptr<const class SyntaxToken> Identifier,
                                       const std::shared_ptr<const class TypeClauseSyntax> Type) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Identifier;
         const std::shared_ptr<const class TypeClauseSyntax> Type;

--- a/src/Mamba/Code Analysis/Syntax/ParenthesizedExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ParenthesizedExpressionSyntax.h
@@ -18,8 +18,8 @@ namespace Mamba
             const std::shared_ptr<const class ExpressionSyntax> Expression,
             const std::shared_ptr<const class SyntaxToken> CloseParenthesisToken) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> OpenParenthesisToken;
         const std::shared_ptr<const class ExpressionSyntax> Expression;

--- a/src/Mamba/Code Analysis/Syntax/ReturnStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/ReturnStatementSyntax.h
@@ -15,8 +15,8 @@ namespace Mamba
                                             const std::shared_ptr<const class SyntaxToken> ReturnKeyword,
                                             const NullableSharedPtr<const class ExpressionSyntax> Expression) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> ReturnKeyword;
         const NullableSharedPtr<const class ExpressionSyntax> Expression;

--- a/src/Mamba/Code Analysis/Syntax/TypeClauseSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/TypeClauseSyntax.h
@@ -15,8 +15,8 @@ namespace Mamba
                                        const std::shared_ptr<const class SyntaxToken> ColonToken,
                                        const std::shared_ptr<const class SyntaxToken> Identifier) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> ColonToken;
         const std::shared_ptr<const class SyntaxToken> Identifier;

--- a/src/Mamba/Code Analysis/Syntax/UnaryExpressionSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/UnaryExpressionSyntax.h
@@ -16,8 +16,8 @@ namespace Mamba
                                             const std::shared_ptr<const class SyntaxToken> OperatorToken,
                                             const std::shared_ptr<const class ExpressionSyntax> Operand) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> OperatorToken;
         const std::shared_ptr<const class ExpressionSyntax> Operand;

--- a/src/Mamba/Code Analysis/Syntax/VariableDeclarationSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/VariableDeclarationSyntax.h
@@ -19,8 +19,8 @@ namespace Mamba
             const std::shared_ptr<const class SyntaxToken> EqualsToken,
             const std::shared_ptr<const class ExpressionSyntax> Initializer) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> Keyword;
         const std::shared_ptr<const class SyntaxToken> Identifier;

--- a/src/Mamba/Code Analysis/Syntax/WhileStatementSyntax.h
+++ b/src/Mamba/Code Analysis/Syntax/WhileStatementSyntax.h
@@ -16,8 +16,8 @@ namespace Mamba
                                            const std::shared_ptr<const class ExpressionSyntax> Condition,
                                            const std::shared_ptr<const class StatementSyntax> Body) noexcept;
 
-        virtual SyntaxKind Kind() const noexcept override;
-        virtual std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
+        SyntaxKind Kind() const noexcept override;
+        std::vector<std::shared_ptr<const class SyntaxNode>> Children() const noexcept override;
 
         const std::shared_ptr<const class SyntaxToken> WhileKeyword;
         const std::shared_ptr<const class ExpressionSyntax> Condition;

--- a/xmake.lua
+++ b/xmake.lua
@@ -19,6 +19,9 @@ target("Jvav")
         set_optimize("fastest")
     end
     if is_mode("debug") then
+        add_cflags("-fsanitize=address")
+        add_ldflags("-fsanitize=address")
+        add_cxxflags("-fsanitize=address", "-fno-omit-frame-pointer", "-fno-optimize-sibling-calls")
         add_defines("DEBUG")
     end
 


### PR DESCRIPTION
Remove redundant virtual specifier
> [The use of the virtual specifier in the declaration of an overriding function is valid but redundant (has empty semantics).](https://eel.is/c++draft/class.virtual#footnote-93.sentence-1)